### PR TITLE
Add deployment script for arm64/Apple Silicon compatibility and update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,4 +51,16 @@ Now that `OTA-API-Developer-Guide` is all set up on your machine, you'll probabl
 ### Deploy to production
 
 - Upload the generated files to the `gh-pages` branch.
-- After that github will upload automatically the changes to the [public domain](https://ota-doc.weekendesk.com/#introduction) 
+- After that github will upload automatically the changes to the [public domain](https://ota-doc.weekendesk.com/#introduction)
+
+### Deploy to production (Apple Silicon / arm64)
+
+Make sure your changes are merged into `master`, then run:
+
+```shell
+./deploy-arm64.sh
+```
+
+This script builds the documentation site inside a Docker container (required for compatibility with arm64 Macs) and publishes the generated files to the `gh-pages` branch, which GitHub Pages serves as the public site at [ota-doc.weekendesk.com](https://ota-doc.weekendesk.com).
+
+> Prerequisites: [Docker Desktop](https://www.docker.com/products/docker-desktop/) must be running.

--- a/deploy-arm64.sh
+++ b/deploy-arm64.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+# Run this script from the master branch once your changes are merged.
+# It builds the static documentation site using Docker and publishes
+# the generated files to the gh-pages branch, which is what GitHub Pages
+# serves as the public documentation site.
+set -o errexit
+
+DOCKER_HOST_BACKUP=$DOCKER_HOST
+unset DOCKER_HOST
+
+cleanup() {
+  export DOCKER_HOST=$DOCKER_HOST_BACKUP
+}
+trap cleanup EXIT
+
+# Build using Docker (compatible with arm64 / Apple Silicon)
+docker --context desktop-linux run --rm --platform linux/amd64 \
+  -v "$(pwd)":/usr/src/app \
+  -w /usr/src/app \
+  ruby:2.7 bash -c "
+    apt-get update -qq &&
+    apt-get install -y -qq nodejs &&
+    gem install bundler:1.14.5 --quiet &&
+    bundle install --quiet &&
+    bundle exec middleman build --clean
+  "
+
+# Deploy to gh-pages
+commit_title=$(git log -n 1 --format="%s" HEAD)
+commit_hash=$(git log -n 1 --format="%H" HEAD)
+
+git symbolic-ref HEAD refs/heads/gh-pages
+git --work-tree build reset --mixed --quiet
+git --work-tree build add --all
+
+if git --work-tree build diff --exit-code --quiet HEAD --; then
+  echo "No changes in build. Nothing to publish."
+else
+  git --work-tree build commit -m "publish: $commit_title
+
+generated from commit $commit_hash"
+
+  git push upstream gh-pages
+  echo "Successfully deployed to gh-pages."
+fi
+
+git symbolic-ref HEAD refs/heads/master
+git reset --mixed


### PR DESCRIPTION
Related to https://github.com/weekendesk/product-management/issues/4984

## Scope
The existing `deploy.sh` relies on `bundle exec middleman build` running locally, which requires native gem compilation. The `ffi` gem bundled with this project (1.9.17) does not compile on arm64 architecture (Apple Silicon), making it impossible to deploy from modern Macs without this workaround.

## Summary
  - Adds `deploy-arm64.sh`, a deploy script compatible with Apple Silicon Macs
  - Uses Docker (linux/amd64) to build the static site, avoiding native gem compilation issues on arm64
  - Pushes the generated files to the `gh-pages` branch, which publishes the public documentation site
  - Documents the new script in the README